### PR TITLE
Add deploy-prod

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,32 @@
+name: "Deploy Production"
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+env:
+  APP_NAME: "gitops-frontend"
+  NAMESPACE: "app-prod-18"
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: "Build and push container"
+        run: |-
+          IMAGE_TAG="${GITHUB_REF#refs/*/}"
+
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:${IMAGE_TAG}"
+
+          docker build -f docker/prod.Dockerfile -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the deployment process for the production environment. The workflow is triggered by pushing tags that match a specific version pattern and includes steps for checking out the code, logging into Docker Hub, and building and pushing a Docker container.

Key changes include:

* **New GitHub Actions Workflow**:
  * Added a new workflow named `Deploy Production` that triggers on push events with tags matching the pattern `v[0-9]+.[0-9]+.[0-9]+`.
  * Set environment variables `APP_NAME` and `NAMESPACE` for the deployment process.
  * Defined a job named `build` that runs on `ubuntu-latest` and includes steps for checking out the repository, logging into Docker Hub, and building and pushing the Docker container.